### PR TITLE
gcc-7.2.0.tar.bz2 doesn't exist

### DIFF
--- a/tools/build-linux64-toolchain.sh
+++ b/tools/build-linux64-toolchain.sh
@@ -12,7 +12,7 @@ set -eu
 #
 
 BINUTILS="ftp://ftp.gnu.org/gnu/binutils/binutils-2.29.tar.bz2"
-GCC="ftp://ftp.gnu.org/gnu/gcc/gcc-7.2.0/gcc-7.2.0.tar.bz2"
+GCC="ftp://ftp.gnu.org/gnu/gcc/gcc-7.2.0/gcc-7.2.0.tar.gz"
 MAKE="ftp://ftp.gnu.org/gnu/make/make-4.2.1.tar.bz2"
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/tools/build-win64-toolchain.sh
+++ b/tools/build-win64-toolchain.sh
@@ -12,7 +12,7 @@ set -eu
 #
 
 BINUTILS="ftp://ftp.gnu.org/gnu/binutils/binutils-2.29.tar.bz2"
-GCC="ftp://ftp.gnu.org/gnu/gcc/gcc-7.2.0/gcc-7.2.0.tar.bz2"
+GCC="ftp://ftp.gnu.org/gnu/gcc/gcc-7.2.0/gcc-7.2.0.tar.gz"
 GMP="ftp://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.bz2"
 MAKE="ftp://ftp.gnu.org/gnu/make/make-4.2.1.tar.bz2"
 MPC="ftp://ftp.gnu.org/gnu/mpc/mpc-1.0.3.tar.gz"


### PR DESCRIPTION
no file: GCC="ftp://ftp.gnu.org/gnu/gcc/gcc-7.2.0/gcc-7.2.0.tar.bz2"
replaced with GCC="ftp://ftp.gnu.org/gnu/gcc/gcc-7.2.0/gcc-7.2.0.tar.gz"
worked for me