### PR TITLE
macOS Build Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 /*/filesystem.h
 *.swp
 
+# macOS Garbage
+.DS_Store
+._*

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ lightweight development environment and thus requires some low-level baby sittin
 
 To build the toolchain, first put your boot code named `header.bin` on the `libn64` folder. Run `build-posix64-toolchain.sh`
 in the `tools` folder on a bash-compatible shell to start building the cross-compiler.
-Prerequisites are GMP, MPFR and MPC with development headers, build-essential, and bison, which can be installed via `apt install build-essential libmpfr-dev libmpc-dev libgmp-dev bison`
+Prerequisites are GMP, MPFR and MPC with development headers, build-essential, and bison, which can be installed via `apt install build-essential libmpfr-dev libmpc-dev libgmp-dev flex bison`
 on Ubuntu. On Mac, the Xcode command-line tools are also required. The other prerequisites can be installed via the homebrew 
-package manager like so `brew install mpfr isl libmpc gmp bison && brew link bison --force`.
+package manager like so `brew install mpfr isl libmpc gmp flex bison && brew link bison --force`.
 
 There is also a Windows compatible version `build-win64-toolchain.sh` that still requires a UNIX-like environment to run.
 

--- a/rspasm/Makefile
+++ b/rspasm/Makefile
@@ -39,7 +39,7 @@ all: rspasm
 
 rspasm: $(OBJFILES)
 	@echo $(call FIXPATH,"Linking: rspasm/$@")
-	@$(CC) -static $(CFLAGS) $(OPTFLAGS) $^ $(RSPASM_LIBS) -o $@
+	@$(CC) $(CFLAGS) $(OPTFLAGS) $^ $(RSPASM_LIBS) -o $@
 
 parser.c: parser.y
 	@echo $(call FIXPATH,"Generating: rspasm/$@")

--- a/tools/build-posix64-toolchain.sh
+++ b/tools/build-posix64-toolchain.sh
@@ -177,13 +177,13 @@ if [ ! -f stamps/make-install ]; then
 fi
 
 if [ ! -f stamps/checksum-build ]; then
-  cc -Wall -Wextra -pedantic -std=c99 -static -O2 checksum.c -o bin/checksum
+  cc -Wall -Wextra -pedantic -std=c99 -O2 checksum.c -o bin/checksum
 
   touch stamps/checksum-build
 fi
 
 if [ ! -f stamps/mkfs-build ]; then
-  cc -Wall -Wextra -pedantic -std=c99 -static -O2 mkfs.c -o bin/mkfs
+  cc -Wall -Wextra -pedantic -std=c99 -O2 mkfs.c -o bin/mkfs
 
   touch stamps/mkfs-build
 fi

--- a/tools/build-win64-toolchain.sh
+++ b/tools/build-win64-toolchain.sh
@@ -218,13 +218,13 @@ if [ ! -f stamps/make-install ]; then
 fi
 
 if [ ! -f stamps/checksum-build ]; then
-  x86_64-w64-mingw32-gcc -Wall -Wextra -pedantic -std=c99 -static -O2 checksum.c -o bin/checksum.exe
+  x86_64-w64-mingw32-gcc -Wall -Wextra -pedantic -std=c99 -O2 checksum.c -o bin/checksum.exe
 
   touch stamps/checksum-build
 fi
 
 if [ ! -f stamps/mkfs-build ]; then
-  x86_64-w64-mingw32-gcc -Wall -Wextra -pedantic -std=c99 -static -O2 mkfs.c -o bin/mkfs.exe
+  x86_64-w64-mingw32-gcc -Wall -Wextra -pedantic -std=c99 -O2 mkfs.c -o bin/mkfs.exe
 
   touch stamps/mkfs-build
 fi


### PR DESCRIPTION
Some minor tweaks to the linux build script that allows it to build on both Linux and Mac. Namely removing the static flag from some build options.

Tested these changes on both Mac and Linux. Project builds, and the examples successfully generate ROM files that can be run on cen64.