### PR TITLE
Fix missing typedef for opcode_t in rspasm

### DIFF
--- a/rspasm/opcodes.h
+++ b/rspasm/opcodes.h
@@ -11,7 +11,7 @@
 #ifndef RSPASM_OPCODES_H
 #define RSPASM_OPCODES_H
 
-enum rsp_opcode {
+typedef enum rsp_opcode {
   BREAK = 0x0000000D,
   NOP = 0x00000000,
   VNOP = 0x4A000037,

--- a/tools/build-posix64-toolchain.sh
+++ b/tools/build-posix64-toolchain.sh
@@ -208,6 +208,9 @@ if [ ! -f stamps/rspasm-build ]; then
 
   make clean && make all -j${numproc}
   cp rspasm ${SCRIPT_DIR}/bin
+  popd
+
+  touch stamps/rspasm-build
 fi
 
 rm -rf "${SCRIPT_DIR}"/../tools/tarballs

--- a/tools/build-win64-toolchain.sh
+++ b/tools/build-win64-toolchain.sh
@@ -235,6 +235,9 @@ if [ ! -f stamps/rspasm-build ]; then
   make clean
   CC=x86_64-w64-mingw32-gcc RSPASM_LIBS="-lws2_32" make
   cp rspasm ${SCRIPT_DIR}/bin/rspasm.exe
+  popd
+
+  touch stamps/rspasm-build
 fi
 
 rm -rf "${SCRIPT_DIR}"/../tools/tarballs


### PR DESCRIPTION
This fix was required to compile on WSL/ArchLinux.
Original error:
```Linking: rspasm/rspasm
/usr/sbin/ld: lexer.o:(.bss+0x0): multiple definition of `opcode_t'; emitter.o:(.bss+0x0): first defined here
/usr/sbin/ld: main.o:(.bss+0x0): multiple definition of `opcode_t'; emitter.o:(.bss+0x0): first defined here
/usr/sbin/ld: parser.o:(.bss+0x0): multiple definition of `opcode_t'; emitter.o:(.bss+0x0): first defined here