### PR TITLE
Add necessary libgcc and helpful newlib to toolchain build scripts

### DIFF
--- a/tools/build-posix64-toolchain.sh
+++ b/tools/build-posix64-toolchain.sh
@@ -23,6 +23,8 @@ BINUTILS="ftp://ftp.gnu.org/gnu/binutils/binutils-2.34.tar.bz2"
 GCC="ftp://ftp.gnu.org/gnu/gcc/gcc-10.1.0/gcc-10.1.0.tar.gz"
 MAKE="ftp://ftp.gnu.org/gnu/make/make-4.2.1.tar.bz2"
 NEWLIB="ftp://sourceware.org/pub/newlib/newlib-3.3.0.tar.gz"
+TCFLAG="-g -O2 -D_MIPS_SZLONG=32 -D_MIPS_SZINT=32 -mabi=32 -march=vr4300 -mtune=vr4300 -mfix4300"
+TCXXFLAG="-g -O2 -D_MIPS_SZLONG=32 -D_MIPS_SZINT=32 -mabi=32 -march=vr4300 -mtune=vr4300 -mfix4300"
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd ${SCRIPT_DIR} && mkdir -p {stamps,tarballs}
@@ -112,7 +114,6 @@ if [ ! -f stamps/gcc-configure ]; then
     --disable-multilib \
     --disable-nls \
     --disable-rpath \
-    --disable-static \
     --disable-threads \
     --disable-win32-registry \
     --enable-lto \
@@ -134,7 +135,10 @@ fi
 
 if [ ! -f stamps/libgcc-build ]; then
   pushd gcc-build
-  make all-target-libgcc CFLAGS_FOR_TARGET='-g -O2 -D_MIPS_SZLONG=32 -D_MIPS_SZINT=32 -mabi=32 -march=vr4300 -mtune=vr4300 -mfix4300' -j${numproc}
+  make all-target-libgcc \
+    CFLAGS_FOR_TARGET="${TCFLAG}" \
+    CXXFLAGS_FOR_TARGET="${TCXXFLAG}" \
+    -j${numproc}
   popd
 
   touch stamps/libgcc-build
@@ -175,8 +179,8 @@ fi
 
 if [ ! -f stamps/newlib-install ]; then
   pushd newlib-build
-  CFLAGS_FOR_TARGET="-mabi=32 -march=vr4300 -mtune=vr4300 -mfix4300 -O2 -g" \
-    CXXFLAGS_FOR_TARGET="-mabi=32 -march=vr4300 -mtune=vr4300 -mfix4300 -O2 -g" \
+  CFLAGS_FOR_TARGET="${TCFLAG}" \
+    CXXFLAGS_FOR_TARGET="${TCXXFLAG}" \
     ../newlib-source/configure --target=mips64-elf --prefix=${SCRIPT_DIR} \
     --with-cpu=mips64vr4300 --disable-threads --disable-libssp --disable-werror
   make -j${numproc}

--- a/tools/build-win64-toolchain.sh
+++ b/tools/build-win64-toolchain.sh
@@ -18,6 +18,8 @@ MAKE="ftp://ftp.gnu.org/gnu/make/make-4.2.1.tar.bz2"
 MPC="ftp://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz"
 MPFR="ftp://ftp.gnu.org/gnu/mpfr/mpfr-4.0.2.tar.bz2"
 NEWLIB="ftp://sourceware.org/pub/newlib/newlib-3.3.0.tar.gz"
+TCFLAG="-g -O2 -D_MIPS_SZLONG=32 -D_MIPS_SZINT=32 -mabi=32 -march=vr4300 -mtune=vr4300 -mfix4300"
+TCXXFLAG="-g -O2 -D_MIPS_SZLONG=32 -D_MIPS_SZINT=32 -mabi=32 -march=vr4300 -mtune=vr4300 -mfix4300"
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd ${SCRIPT_DIR} && mkdir -p {stamps,tarballs}
@@ -144,12 +146,12 @@ if [ ! -f stamps/gcc-configure ]; then
     --disable-multilib \
     --disable-nls \
     --disable-rpath \
-    --disable-static \
     --disable-symvers \
     --disable-threads \
     --disable-win32-registry \
     --enable-lto \
     --enable-plugin \
+    --enable-static \
     --without-included-gettext
   popd
 
@@ -166,7 +168,9 @@ fi
 
 if [ ! -f stamps/libgcc-build ]; then
   pushd gcc-build
-  make all-target-libgcc CFLAGS_FOR_TARGET='-g -O2 -D_MIPS_SZLONG=32 -D_MIPS_SZINT=32 -mabi=32 -march=vr4300 -mtune=vr4300 -mfix4300'
+  make all-target-libgcc \
+    CFLAGS_FOR_TARGET="${TCFLAG}" \
+    CXXFLAGS_FOR_TARGET="${TCXXFLAG}" \
   popd
 
   touch stamps/libgcc-build
@@ -206,8 +210,8 @@ fi
 
 if [ ! -f stamps/newlib-install ]; then
   pushd newlib-build
-  CFLAGS_FOR_TARGET="-mabi=32 -march=vr4300 -mtune=vr4300 -mfix4300 -O2 -g" \
-    CXXFLAGS_FOR_TARGET="-mabi=32 -march=vr4300 -mtune=vr4300 -mfix4300 -O2 -g" \
+  CFLAGS_FOR_TARGET="${TCFLAG}" \
+    CXXFLAGS_FOR_TARGET="${TCXXFLAG}" \
     ../newlib-source/configure --target=mips64-elf --prefix=${SCRIPT_DIR} \
     --with-cpu=mips64vr4300 --disable-threads --disable-libssp --disable-werror
   make


### PR DESCRIPTION
libgcc contains functions the compiler will emit automatically such as casts to/from wider-than-word types.  While the proprietary libkmc of the official n64sdk contains most (but not all) of these functions, libgcc is the standard way of providing them and we should be building it.

Newlib contains basic libc functions (like memmove) that are generally useful, but not strictly required.

The libgcc works just fine, although I didn't modify any of the examples to pull it in (i.e. -lgcc) as they don't have accesses/casts/etc. that provoke a call to it.  Newlib builds and works well enough to replace libkmc in my limited testing, although using stddef from libn64 will prevent some newlib headers from working (like string.h).  Nothing forces the use of newlib, and it's simply there if someone wishes to use it.

In addition to the posix64 script, I made the same changes to build-win64, but I'm on Linux so someone with a Windows setup needs to make sure it still works.

This closes #21 