### PR TITLE
Update gnu url to use https instead of ftp

### DIFF
--- a/tools/build-posix64-toolchain.sh
+++ b/tools/build-posix64-toolchain.sh
@@ -19,9 +19,9 @@ which getconf >/dev/null 2>/dev/null && {
 
 numproc=`getnumproc`
 
-BINUTILS="ftp://ftp.gnu.org/gnu/binutils/binutils-2.34.tar.bz2"
-GCC="ftp://ftp.gnu.org/gnu/gcc/gcc-10.1.0/gcc-10.1.0.tar.gz"
-MAKE="ftp://ftp.gnu.org/gnu/make/make-4.3.tar.gz"
+BINUTILS="https://ftp.gnu.org/gnu/binutils/binutils-2.34.tar.bz2"
+GCC="https://ftp.gnu.org/gnu/gcc/gcc-10.1.0/gcc-10.1.0.tar.gz"
+MAKE="https://ftp.gnu.org/gnu/make/make-4.3.tar.gz"
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd ${SCRIPT_DIR} && mkdir -p {stamps,tarballs}


### PR DESCRIPTION
i was trying to build for fedora 41 but i got this error
![image](https://github.com/user-attachments/assets/b91eaa60-362c-455a-9dec-61e8970ba522)
