### PR TITLE
Using ftp mirrors for tools in order to speed-up download speeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,11 @@
 /tools/libexec
 /tools/mips64-elf
 /tools/share
+/tools/stamps
+/tools/tarballs
+/tools/*-build
 /tools/*-linux-gnu
+/tools/*-source
 
 *.a
 *.bin

--- a/tools/build-posix64-toolchain.sh
+++ b/tools/build-posix64-toolchain.sh
@@ -19,9 +19,9 @@ which getconf >/dev/null 2>/dev/null && {
 
 numproc=`getnumproc`
 
-BINUTILS="ftp://ftp.gnu.org/gnu/binutils/binutils-2.34.tar.bz2"
-GCC="ftp://ftp.gnu.org/gnu/gcc/gcc-10.1.0/gcc-10.1.0.tar.gz"
-MAKE="ftp://ftp.gnu.org/gnu/make/make-4.3.tar.gz"
+BINUTILS="https://ftpmirror.gnu.org/binutils/binutils-2.34.tar.bz2"
+GCC="https://ftpmirror.gnu.org/gnu/gcc/gcc-10.1.0/gcc-10.1.0.tar.gz"
+MAKE="https://ftpmirror.gnu.org/gnu/make/make-4.3.tar.gz"
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd ${SCRIPT_DIR} && mkdir -p {stamps,tarballs}


### PR DESCRIPTION
Download speeds are limited to 50-100kbits/s if the original ftp servers are used. Instead, we should be using a dynamic ftp mirror to get much faster download speeds. This cuts down the creation time for the tools by around one hour.